### PR TITLE
DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/study/studyprojectboard/response/ArticleCommentResponse.java
+++ b/src/main/java/com/study/studyprojectboard/response/ArticleCommentResponse.java
@@ -2,7 +2,6 @@ package com.study.studyprojectboard.response;
 
 import com.study.studyprojectboard.dto.ArticleCommentDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleCommentResponse(
@@ -11,7 +10,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleCommentResponse(id, content, createdAt, email, nickname);

--- a/src/main/java/com/study/studyprojectboard/response/ArticleResponse.java
+++ b/src/main/java/com/study/studyprojectboard/response/ArticleResponse.java
@@ -2,7 +2,6 @@ package com.study.studyprojectboard.response;
 
 import com.study.studyprojectboard.dto.ArticleDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 public record ArticleResponse(
@@ -13,7 +12,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
 
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);

--- a/src/main/java/com/study/studyprojectboard/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/study/studyprojectboard/response/ArticleWithCommentsResponse.java
@@ -2,7 +2,6 @@ package com.study.studyprojectboard.response;
 
 import com.study.studyprojectboard.dto.ArticleWithCommentsDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -17,7 +16,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+) {
 
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
         return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);


### PR DESCRIPTION
생성 당시 자동으로 `implements Serializable` 이 들어가버림
이 프로젝트는 직렬화로 Jackson을 사용하므로
필요하지 않고, 의도적으로 넣은 코드가 아니므로 삭제 조치